### PR TITLE
Issue 9 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ modules/**/src_lib/*
 .recommenders
 .recommenders/
 .recommenders/**/*
+/.idea

--- a/build.xml
+++ b/build.xml
@@ -483,7 +483,7 @@
       
       <exec dir="." os="Mac OS X" executable="/bin/sh">
         <arg value="-c"/>
-      <arg value="./mkdmg.sh /${jam.dist.dir}/appbundler/jam50-fritzbox/ ./${jam.pub.dir}/ jam50-macosx-fritzbox-oracle"/>
+      <arg value="./mkdmg.sh ./${jam.dist.dir}/appbundler/jam50-fritzbox/ ./${jam.pub.dir}/ jam50-macosx-fritzbox-oracle"/>
       </exec>
 	</target>
     

--- a/build.xml
+++ b/build.xml
@@ -301,7 +301,6 @@
       </copy>
       <zip zipfile="${jam.pub.dir}/jam50-win64-ncid.zip" basedir="${jam.dist.dir}/jam50-win64-ncid"/>  
 
-
       <echo message="Publishing win64 client version..." />
       <copy todir="${jam.dist.dir}/jam50-win64-client">
           <fileset dir="${jam.dist.dir}/jam50-win64"/>
@@ -409,7 +408,7 @@
      
     </target>
 
-	<target name="bundle_macosx64_oracle" depends="init_bundle,macosx64_distribution" description="create macosx64 bundles" if="is.macosx">
+  <target name="bundle_macosx64_oracle" depends="init_bundle,build_modules,macosx64_distribution" description="create macosx64 bundles" if="is.macosx">
 	  <property environment="env"/>
 
 	  <!-- Define the appbundler task -->
@@ -461,11 +460,11 @@
         name="jAnrufmonitor - AVM FRITZ!Box Edition"
         displayname="jAnrufmonitor - AVM FRITZ!Box Edition"
         identifier="de.janrufmonitor.core"
+                copyright="jAnrufmonitor 5.0, copyright 2008 - 2017"
         icon="./kernel/core/deployment/macosx64/images/jam.icns" 
         shortversion="${jam.version}"
         applicationCategory="public.app-category.productivity"
         mainclassname="de/janrufmonitor/application/RunUI64">
-		<runtime dir="${env.JAVA_HOME}" />
 		<classpath dir="${jam.dist.dir}/jam50-macosx64-fritzbox" >
             <include name="**/*.jar" />
 	    <include name="structure.zip" />
@@ -484,12 +483,12 @@
       
       <exec dir="." os="Mac OS X" executable="/bin/sh">
         <arg value="-c"/>
-        <arg value="./mkdmg.sh /Users/brandtt/git/janrufmonitor/ ./${jam.dist.dir}/appbundler/jam50-fritzbox/ ./${jam.pub.dir}/ jam50-macosx-fritzbox-oracle"/>
+      <arg value="./mkdmg.sh /${jam.dist.dir}/appbundler/jam50-fritzbox/ ./${jam.pub.dir}/ jam50-macosx-fritzbox-oracle"/>
       </exec>
 	</target>
     
-    <target name="bundle_macosx64" depends="init_bundle,macosx64_distribution" description="create macosx64 bundles" if="is.macosx">
-      <taskdef name="jarbundler" classname="net.sourceforge.jarbundler.JarBundler" classpath="./ant/lib/jarbundler-2.3.1.jar"/>
+  <target name="bundle_macosx64" depends="init_bundle,build_modules,macosx64_distribution" description="create macosx64 bundles" if="is.macosx">
+    <taskdef name="jarbundler" classname="com.ultramixer.jarbundler.JarBundler" classpath="./ant/lib/jarbundler-core-3.3.0.jar"/>
 
       <echo message="Publishing macosx64 fritzbox version..." />
       <copy todir="${jam.dist.dir}/jam50-macosx64-fritzbox">
@@ -538,12 +537,13 @@
               icon="./kernel/core/deployment/macosx64/images/jam.icns"
               jvmversion="1.6+"
               version="${jam.version}"
-              infostring="jAnrufmonitor 5.0, copyright 2008 - 2017"
+              copyright="jAnrufmonitor 5.0, copyright 2008 - 2017"
               build="${jam.version}"
               bundleid="de.janrufmonitor.core" 
               startOnMainThread="true"
               isAgent="yes"
               developmentregion="German"
+              allowmixedlocalizations="true"
               vmoptions="-Djam.ui.toplevel=false -Djam.ui.trayitem=true -Xms16m -Xmx256m"> 
                 
         <!-- Adjust the look, feel and behavior -->
@@ -569,7 +569,7 @@
       
       <exec dir="." os="Mac OS X" executable="/bin/sh">
         <arg value="-c"/>
-        <arg value="./mkdmg.sh /Users/brandtt/git/janrufmonitor/ ./${jam.dist.dir}/jarbundler/jam50-fritzbox/ ./${jam.pub.dir}/ jam50-macosx-fritzbox"/>
+      <arg value="./mkdmg.sh ./${jam.dist.dir}/jarbundler/jam50-fritzbox/ ./${jam.pub.dir}/ jam50-macosx-fritzbox"/>
       </exec>
       
 
@@ -620,11 +620,12 @@
               icon="./kernel/core/deployment/macosx64/images/jam.icns"
               jvmversion="1.6+"
               version="${jam.version}"
-              infostring="jAnrufmonitor 5.0, copyright 2008 - 2017"
+              copyright="jAnrufmonitor 5.0, copyright 2008 - 2017"
               build="${jam.version}"
               bundleid="de.janrufmonitor.core" 
               startOnMainThread="true"
               isAgent="yes"
+              allowmixedlocalizations="true"
               developmentregion="German"
               vmoptions="-Djam.ui.toplevel=false -Djam.ui.trayitem=true -Xms16m -Xmx256m"> 
                 
@@ -651,7 +652,7 @@
       
       <exec dir="." os="Mac OS X" executable="/bin/sh">
         <arg value="-c"/>
-        <arg value="./mkdmg.sh /Users/brandtt/git/janrufmonitor/ ./${jam.dist.dir}/jarbundler/jam50-ncid/ ./${jam.pub.dir}/ jam50-macosx-ncid"/>
+      <arg value="./mkdmg.sh ./${jam.dist.dir}/jarbundler/jam50-ncid/ ./${jam.pub.dir}/ jam50-macosx-ncid"/>
       </exec>
 
       
@@ -702,11 +703,12 @@
               icon="./kernel/core/deployment/macosx64/images/jam.icns"
               jvmversion="1.6+"
               version="${jam.version}"
-              infostring="jAnrufmonitor 5.0, copyright 2008 - 2017"
+              copyright="jAnrufmonitor 5.0, copyright 2008 - 2017"
               build="${jam.version}"
               bundleid="de.janrufmonitor.core" 
               startOnMainThread="true"
               isAgent="yes"
+              allowmixedlocalizations="true"
               developmentregion="German"
               vmoptions="-Djam.ui.toplevel=false -Djam.ui.trayitem=true -Xms16m -Xmx256m"> 
                 
@@ -733,7 +735,7 @@
       
       <exec dir="." os="Mac OS X" executable="/bin/sh">
         <arg value="-c"/>
-        <arg value="./mkdmg.sh /Users/brandtt/git/janrufmonitor/ ./${jam.dist.dir}/jarbundler/jam50-client/ ./${jam.pub.dir}/ jam50-macosx-client"/>
+      <arg value="./mkdmg.sh ./${jam.dist.dir}/jarbundler/jam50-client/ ./${jam.pub.dir}/ jam50-macosx-client"/>
       </exec>
     </target>
     
@@ -927,17 +929,6 @@
         <delete dir="${jam.build.root}" />
         <delete dir="${jam.dist.root}" />
     </target>   
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
     
     
 <macrodef name="create-bundle">

--- a/mkdmg.sh
+++ b/mkdmg.sh
@@ -1,29 +1,18 @@
-#!/bin/sh
+#!/usr/bin/env bash -x
 
-BASE="$1"
-SRC="$2"
-DEST="$3"
-VOLUME="$4"
+SRC="$1"
+DEST="$2"
+VOLUME="$3"
+DMG_PATH="${DEST}${VOLUME}.dmg"
 
-echo Base Directory $1
-echo Source $2
-echo Destination $3
-echo Volume $4
+echo Source: ${SRC}
+echo Destination: ${DEST}
+echo Volume: ${VOLUME}
+echo DMG-Path: ${DMG_PATH}
 
 TEMP="TEMPORARY"
 
-cd $BASE
+## cd $BASE
 
-hdiutil create -srcfolder "$SRC" $DEST$VOLUME.dmg
-hdiutil internet-enable -yes $DEST$VOLUME.dmg
-
-#hdiutil create -megabytes 5 $DEST$TEMP.dmg -layout NONE
-#MY_DISK=`hdid -nomount $DEST$TEMP.dmg`
-#newfs_hfs -v $VOLUME $MY_DISK
-#hdiutil eject $MY_DISK
-#hdid $DEST$TEMP.dmg
-#chflags -R nouchg,noschg "$SRC"
-#ditto -rsrcFork -v "$SRC" "/Volumes/$VOLUME"
-#hdiutil eject $MY_DISK
-#hdiutil convert -format UDCO $DEST$TEMP.dmg -o $DEST$VOLUME.dmg
-#hdiutil internet-enable -yes $DEST$VOLUME.dmg
+/usr/bin/hdiutil create -srcfolder "${SRC}" "${DMG_PATH}"
+/usr/bin/hdiutil internet-enable -yes "${DMG_PATH}"


### PR DESCRIPTION
- PR for #9
- do not use universalJavaApplicationStub, as project will be migrated to Oracle Java anyway
- cleanup mkdmg.sh: 
  - remove first, unused param 
  - do not cd into $BASE (as we are there already)
  - variable handling

- depend bundle_maxosx64_oracle on build_modules, otherwise we need to build them manually
- remove "runtime" attribute due to licensing issues (user must install Oracle Java before usage)
- add copyright attribute
