### PR TITLE
Ensure Shell is opened in foreground when opened from TrayIcon (OSX)

### DIFF
--- a/kernel/core/src/ui/de/janrufmonitor/ui/jface/application/info/InfoCommand.java
+++ b/kernel/core/src/ui/de/janrufmonitor/ui/jface/application/info/InfoCommand.java
@@ -44,7 +44,9 @@ public class InfoCommand extends AbstractAsyncDisplayCommand implements IConfigu
 	}
 
 	public void asyncExecute() {
-		InfoDialog id = new InfoDialog(new Shell(DisplayManager.getDefaultDisplay()));
+		Shell s = new Shell(DisplayManager.getDefaultDisplay());
+		InfoDialog id = new InfoDialog(s);
+		DisplayManager.forceForeground(s);
 		id.open();
 	}
 

--- a/kernel/core/src/ui/de/janrufmonitor/ui/jface/application/update/UpdatesCommand.java
+++ b/kernel/core/src/ui/de/janrufmonitor/ui/jface/application/update/UpdatesCommand.java
@@ -56,12 +56,14 @@ public class UpdatesCommand extends AbstractAsyncDisplayCommand implements IConf
 		try {
 			WizardDialog.setDefaultImage(SWTImageManager.getInstance(this.getRuntime()).get(IJAMConst.IMAGE_KEY_PIM_ICON));
 			UpdateWizard updates = new UpdateWizard(this.m_preload);
-		    WizardDialog dlg = new WizardDialog(new Shell(DisplayManager.getDefaultDisplay()), updates);
-		    dlg.open();
-		    this.m_preload = false;
-		    if (dlg.getReturnCode() == WizardDialog.OK) {
-		    	
-		    }
+			Shell s = new Shell(DisplayManager.getDefaultDisplay());
+			WizardDialog dlg = new WizardDialog(s, updates);
+			DisplayManager.forceForeground(s);
+			dlg.open();
+			this.m_preload = false;
+			if (dlg.getReturnCode() == WizardDialog.OK) {
+
+			}
 		} catch (Throwable t) {
 			this.m_logger.log(Level.SEVERE, t.getMessage(), t);
 			PropagationFactory.getInstance().fire(new Message(Message.ERROR, this.getNamespace(), t.toString().toLowerCase(), t));

--- a/kernel/core/src/ui/de/janrufmonitor/ui/jface/configuration/ConfigurationCommand.java
+++ b/kernel/core/src/ui/de/janrufmonitor/ui/jface/configuration/ConfigurationCommand.java
@@ -57,9 +57,8 @@ public class ConfigurationCommand extends AbstractConfigurableCommand implements
 			PreferenceDialog.setDefaultImage(SWTImageManager.getInstance(this.getRuntime()).get(IJAMConst.IMAGE_KEY_PIM_ICON));
 			PreferenceDialog dlg = new PreferenceDialog(s, mgr);
 			dlg.setPreferenceStore(new PreferenceConfigManagerStore());
-			s.forceActive();
+			DisplayManager.forceForeground(s);
 			dlg.open();
-
 		} catch (Throwable t) {
 			t.printStackTrace();
 			this.m_logger.log(Level.SEVERE, t.getMessage(), t);

--- a/kernel/core/src/ui/de/janrufmonitor/ui/jface/configuration/ConfigurationCommand.java
+++ b/kernel/core/src/ui/de/janrufmonitor/ui/jface/configuration/ConfigurationCommand.java
@@ -57,7 +57,7 @@ public class ConfigurationCommand extends AbstractConfigurableCommand implements
 			Shell shell = new Shell(display);
 			PreferenceDialog dlg = new PreferenceDialog(shell, mgr);
 			dlg.setPreferenceStore(new PreferenceConfigManagerStore());
-			shell.forceActive();
+			DisplayManager.forceForeground(display, shell);
 			dlg.open();
 
 		} catch (Throwable t) {

--- a/kernel/core/src/ui/de/janrufmonitor/ui/jface/configuration/ConfigurationCommand.java
+++ b/kernel/core/src/ui/de/janrufmonitor/ui/jface/configuration/ConfigurationCommand.java
@@ -54,8 +54,10 @@ public class ConfigurationCommand extends AbstractConfigurableCommand implements
 			
 			// create a PreferenceDialog
 			PreferenceDialog.setDefaultImage(SWTImageManager.getInstance(this.getRuntime()).get(IJAMConst.IMAGE_KEY_PIM_ICON));
-			PreferenceDialog dlg = new PreferenceDialog(new Shell(display), mgr);
+			Shell shell = new Shell(display);
+			PreferenceDialog dlg = new PreferenceDialog(shell, mgr);
 			dlg.setPreferenceStore(new PreferenceConfigManagerStore());
+			shell.forceActive();
 			dlg.open();
 
 		} catch (Throwable t) {

--- a/kernel/framework/src/ui/de/janrufmonitor/ui/swt/DisplayManager.java
+++ b/kernel/framework/src/ui/de/janrufmonitor/ui/swt/DisplayManager.java
@@ -49,22 +49,29 @@ public class DisplayManager {
 	}
 
 	/**
-	 * Force the underlying shell to be displayed on the foreground.
-	 * @param display Actual display
+	 * Force the shell to be displayed on the foreground.
 	 * @param shell underlying shell
 	 */
-	public static void forceForeground(Display display, final Shell shell){
-		display.syncExec(new Runnable() {
-
-			@Override
-			public void run() {
-				m_logger.info("Forcing window to foreground");
-				if (!shell.getMinimized()) shell.setMinimized(true);
-				shell.setMinimized(false);
-				shell.setActive();
+	public static void forceForeground(Shell shell){
+		if (shell == null) return;
+		if (OSUtils.isMacOSX()){
+			// #20 forceActive() does not work on Cocoa (tested up to SWT 4.6.2)
+			// Workaround is to make the shell visible for a short time
+			if (!shell.getVisible()) {
+				shell.setVisible(true);
+				try {
+					Thread.sleep(100);
+				} catch (InterruptedException e) {
+					m_logger.warning("forceForeground() Thread was interrupted.");
+				}
 			}
-		});
+			shell.forceActive();
+			shell.setVisible(false);
+		} else {
+			shell.forceActive();
+		}
 	}
+
 	private synchronized static void createUIThread() {
 		if (isUIThread) {
 			if (m_logger.isLoggable(Level.WARNING))

--- a/kernel/framework/src/ui/de/janrufmonitor/ui/swt/DisplayManager.java
+++ b/kernel/framework/src/ui/de/janrufmonitor/ui/swt/DisplayManager.java
@@ -1,17 +1,17 @@
 package de.janrufmonitor.ui.swt;
 
+import de.janrufmonitor.framework.IJAMConst;
+import de.janrufmonitor.util.io.OSUtils;
+import de.janrufmonitor.util.io.PathResolver;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
-
-import org.eclipse.swt.widgets.Display;
-
-import de.janrufmonitor.framework.IJAMConst;
-import de.janrufmonitor.util.io.OSUtils;
-import de.janrufmonitor.util.io.PathResolver;
 
 public class DisplayManager {
 	

--- a/kernel/framework/src/ui/de/janrufmonitor/ui/swt/DisplayManager.java
+++ b/kernel/framework/src/ui/de/janrufmonitor/ui/swt/DisplayManager.java
@@ -47,7 +47,24 @@ public class DisplayManager {
 		if (t!=null) t = null;
 		isUIThread = false;
 	}
-	
+
+	/**
+	 * Force the underlying shell to be displayed on the foreground.
+	 * @param display Actual display
+	 * @param shell underlying shell
+	 */
+	public static void forceForeground(Display display, final Shell shell){
+		display.syncExec(new Runnable() {
+
+			@Override
+			public void run() {
+				m_logger.info("Forcing window to foreground");
+				if (!shell.getMinimized()) shell.setMinimized(true);
+				shell.setMinimized(false);
+				shell.setActive();
+			}
+		});
+	}
 	private synchronized static void createUIThread() {
 		if (isUIThread) {
 			if (m_logger.isLoggable(Level.WARNING))


### PR DESCRIPTION
#20 After many tries, I found a workaround for the OSX problem. 
We need to set the Shell visible for a short time, forceActive() and then set invisible. 

Implementation: 
```java
DisplayManager.forceForeground(Shell shell)
```

Fixed TrayIcon menu commands:
- ConfigurationCommand 
- UpdatesCommand
- InfoCommand
 
Not fixed, yet:
- InitializerWizard (opens in background all the time if other applications are open. Very annoying and irritating for new users)
- Journal
- Contacts
- Last10Calls
- DialerCommand

